### PR TITLE
Add return type `mixed` to `Wizaplace\Etl\Row::offsetGet`

### DIFF
--- a/src/Row.php
+++ b/src/Row.php
@@ -177,7 +177,7 @@ class Row implements \ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->attributes[$offset];
     }


### PR DESCRIPTION
As of PHP 8.1 the `\ArrayAccess` interface defines a return type on `offsetGet` of `mixed`.  `Wizaplace\Etl\Row`, which implements `ArrayAccess`, does not include the return type, causing the following error on PHP 8.1+.

```
Deprecated: Return type of Wizaplace\Etl\Row::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in ...
```

This commit adds the return type to `Wizaplace\Etl\Row::offsetGet`