### PR TITLE
Update Row.php

### DIFF
--- a/src/Row.php
+++ b/src/Row.php
@@ -177,6 +177,7 @@ class Row implements \ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->attributes[$offset];

--- a/src/Row.php
+++ b/src/Row.php
@@ -174,11 +174,8 @@ class Row implements \ArrayAccess
      * Get the value for a given offset.
      *
      * @param mixed $offset
-     *
-     * @return mixed
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->attributes[$offset];
     }


### PR DESCRIPTION
As of PHP 8.1 the `\ArrayAccess` interface defines a return type on `offsetGet` of mixed. `Wizaplace\Etl\Row`, which implements `ArrayAccess`, does not include the return type, causing the following error on PHP 8.1+.

```
Deprecated: Return type of Wizaplace\Etl\Row::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in ...
```

This PR adds the `#[\ReturnTypeWillChange]` attribute to `Wizaplace\Etl\Row::offsetGet`.

Ideally we would simply add the return type `mixed` instead, but this does not exist in PHP 7.4 and there does not appear to be separate versions of this package for 7.4 and 8.x