### PR TITLE
Add `@mixin Pipeline` to `Etl`

### DIFF
--- a/src/Etl.php
+++ b/src/Etl.php
@@ -15,6 +15,9 @@ use Wizaplace\Etl\Extractors\Extractor;
 use Wizaplace\Etl\Loaders\Loader;
 use Wizaplace\Etl\Transformers\Transformer;
 
+/**
+ * @mixin Pipeline
+ */
 class Etl
 {
     /**


### PR DESCRIPTION
`Etl` uses a magic `__call()` method to pass function requests down to pipeline.  This confuses my IDE (PHPStorm).  Adding the `@mixin` annotation to `Etl` allows the IDE to parse the available functions correctly.