### PR TITLE
Don't call `Pipeline::valid()` recursively when a row is discarded

### DIFF
--- a/src/Pipeline.php
+++ b/src/Pipeline.php
@@ -126,10 +126,7 @@ class Pipeline implements \Iterator
 
         foreach ($this->steps as $step) {
             if ($this->current->discarded()) {
-                $this->key--;
-                $this->next();
-
-                return $this->valid();
+                break;
             }
 
             if ($step instanceof Transformer) {


### PR DESCRIPTION
Currently, when a row is discarded (e.g. by the Transformer), the Pipeline::valid function manually increments the current key, then calls itself recursively.  When discarding many rows, this not only leads to extremely deep call stacks, it also seems to cause execution time to grow linearly as extraction loop progresses.

By changing the discarded behaviour to a simple `break;` statement the valid function will simply return `true`, bypassing subsequent steps (e.g. the Loader) and progressing on to the next row without recursion.