### PR TITLE
update jsonpath package requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": "~8.1",
-        "softcreatr/jsonpath": "^0.7.2"
+        "softcreatr/jsonpath": "^0.8.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
We want to use this package but the version constraint of the package  `softcreatr/jsonpath` is not allowing us to use the current version

```
    - Root composer.json requires wizaplace/php-etl ^2.3.0 -> satisfiable by wizaplace/php-etl[2.3.0].
    - wizaplace/php-etl 2.3.0 requires softcreatr/jsonpath ^0.7.2 -> found softcreatr/jsonpath[0.7.2, ..., 0.7.6] but it conflicts with your root composer.json require (^0.8.3).
```

So here i would upgrade to 0.8.3, 0.8 also drops support for php7.* which should be fine

There is also a package version 0.9.1 out for softcreatr/jsonpath so we might even change to that

first open source contribution, hope its fine like this :)